### PR TITLE
Changing Bitcoin (BCH) text to Bitcoin Cash (BCH)

### DIFF
--- a/app/views/arguments/show.html.slim
+++ b/app/views/arguments/show.html.slim
@@ -20,7 +20,7 @@
                 .section
                   =form_tag(argument_signatures_path(@argument.id), {remote:true, id:"signature_form"}) do |f|
                     .section
-                      .alert.transparent Please copy the above statement, sign it with your Bitcoin (BCH) address, and paste signature here
+                      .alert.transparent Please copy the above statement, sign it with your Bitcoin Cash (BCH) address, and paste signature here
                     .section
                       .input-group
                         =text_field("signature", "signature", {style:"font-size:1em;width:100%;", placeholder:"Place signature here", class:"submit_on_edit"})
@@ -30,7 +30,7 @@
                     .section
                       .alert.transparent
                         | Warning:&nbsp;
-                        a href="https://www.reddit.com/r/btc/comments/4mhjh3/psa_bitcoinocracycom_signatures_expose_your/" rel="nofollow" target="_blank" Bitcoin (BCH) signatures expose your public keys
+                        a href="https://www.reddit.com/r/btc/comments/4mhjh3/psa_bitcoinocracycom_signatures_expose_your/" rel="nofollow" target="_blank" Bitcoin Cash (BCH) signatures expose your public keys
                         | &nbsp;(that shouldn't be a problem until&nbsp;
                         a href="https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm" rel="nofollow" target="_blank" ECDSA
                         |  is broken). Moreover address reuse with a faulty random number generator&nbsp;
@@ -139,7 +139,7 @@
   #sign_message
     .tooltip-content
       h3 How do I sign a message?
-      p Many Bitcoin (BCH) wallet software programs have built-in message signing functionality that allows you to sign a message with the Bitcoin (BCH) key you possess; you can choose a wallet if you don’t have one already. Most wallets will have an area where your address is displayed that you can copy the voting argument into it and sign the message. After signing, the program will return a cryptographically secure signature for you to paste into the Argument page for verification.
+      p Many Bitcoin Cash (BCH) wallet software programs have built-in message signing functionality that allows you to sign a message with the Bitcoin Cash (BCH) key you possess; you can choose a wallet if you don’t have one already. Most wallets will have an area where your address is displayed that you can copy the voting argument into it and sign the message. After signing, the program will return a cryptographically secure signature for you to paste into the Argument page for verification.
 
 #copied-successfully.modal.zoom-anim-dialog.mfp-hide
   h1 Proposition copied successfully

--- a/app/views/layouts/_hero.html.slim
+++ b/app/views/layouts/_hero.html.slim
@@ -2,7 +2,7 @@
   .hero-content.flex-row
     .logo
       = image_tag('logo-bitcoinocracy.png', alt: 'Bitcoin')
-      h1 Vote with your Bitcoin (BCH) signature
+      h1 Vote with your Bitcoin Cash (BCH) signature
     .content.text-left
-      p Bitcoinocracy is a free and decentralized way to measure the Bitcoin (BCH) community's stance on a given proposition.
-      p Voting requires proof of Bitcoin (BCH) holdings via cryptographic signature. Signed votes cannot be forged, and are fully auditable by all users.
+      p Bitcoinocracy is a free and decentralized way to measure the Bitcoin Cash (BCH) community's stance on a given proposition.
+      p Voting requires proof of Bitcoin Cash (BCH) holdings via cryptographic signature. Signed votes cannot be forged, and are fully auditable by all users.

--- a/app/views/layouts/_social_tags.html.slim
+++ b/app/views/layouts/_social_tags.html.slim
@@ -2,10 +2,10 @@ meta content="website" property="og:type" /
 meta content="#{request.original_url}" property="og:url" /
 meta content="Bitcoinocracy - #{title}" property="og:title" /
 meta content="#{image_url('bitcoinocracy-share.jpg')}" property="og:image" /
-meta content="Vote with your Bitcoin (BCH) signature! Bitcoinocracy is a free and decentralized way to measure the Bitcoin (BCH) community's stance on a given proposition." property="og:description" /
+meta content="Vote with your Bitcoin Cash (BCH) signature! Bitcoinocracy is a free and decentralized way to measure the Bitcoin Cash (BCH) community's stance on a given proposition." property="og:description" /
 meta content="summary_large_image" name="twitter:card" /
 meta content="@BTCTN" name="twitter:site" /
 meta content="#{request.original_url}" name="twitter:url" /
 meta content="Bitcoinocracy - #{title}" name="twitter:title" /
-meta content="Vote with your Bitcoin (BCH) signature! Bitcoinocracy is a free and decentralized way to measure the Bitcoin (BCH) community's stance on a given proposition." name="twitter:description" /
+meta content="Vote with your Bitcoin Cash (BCH) signature! Bitcoinocracy is a free and decentralized way to measure the Bitcoin Cash (BCH) community's stance on a given proposition." name="twitter:description" /
 meta content="#{image_url('bitcoinocracy-share.jpg')}" name="twitter:image" /

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,9 +23,9 @@ en:
   arguments:
     index:
       new: Submit your Proposition
-      title: Vote with your Bitcoin (BCH) signature
+      title: Vote with your Bitcoin Cash (BCH) signature
   addresses:
-    index: Bitcoin (BCH) Addresses
+    index: Bitcoin Cash (BCH) Addresses
   faq: FAQ
   activerecord:
     models:


### PR DESCRIPTION
Making updates to Bitcoin (BCH) text to follow the naming convention Bitcoin Cash (BCH).